### PR TITLE
Test Script for Temporary Menus

### DIFF
--- a/RoboVac Unity/Assets/Materials/Floor coverings.meta
+++ b/RoboVac Unity/Assets/Materials/Floor coverings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e85612d0589f64142a60053f9ada5815
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RoboVac Unity/Assets/Scenes/tj.unity
+++ b/RoboVac Unity/Assets/Scenes/tj.unity
@@ -294,6 +294,7 @@ GameObject:
   - component: {fileID: 2065904801}
   - component: {fileID: 2065904800}
   - component: {fileID: 2065904799}
+  - component: {fileID: 2065904803}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -382,6 +383,18 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!114 &2065904803
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2065904798}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8f1b4eaba76c90140b81bb2ebedc732d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &956242286015731694
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/RoboVac Unity/Assets/Scripts/NewFloorPlanMenuManager.cs
+++ b/RoboVac Unity/Assets/Scripts/NewFloorPlanMenuManager.cs
@@ -1,15 +1,23 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using TMPro;
 
 public class NewFloorPlanMenuManager : MonoBehaviour
 {
     public GameObject menu;
 
+    public TextMeshProUGUI fileName;
+    public TextMeshProUGUI roomWidth;
+    public TextMeshProUGUI roomHeight;
+    public TextMeshProUGUI carpetType;
+
+    public TestSimScript simScript;
+
     // Start is called before the first frame update
     void Start()
     {
-        
+        simScript = GetComponentInParent<TestSimScript>();
     }
 
     // Update is called once per frame
@@ -18,8 +26,19 @@ public class NewFloorPlanMenuManager : MonoBehaviour
         
     }
 
+    public void SendData()
+    {
+        //Debug.Log(fileName.text);
+        //Debug.Log(roomWidth.text);
+        //Debug.Log(roomHeight.text);
+        //Debug.Log(carpetType.text);
+
+    }
+
     public void Close()
     {
+        simScript.SaySomething(fileName.text);
+
         Destroy(menu);
     }
 }

--- a/RoboVac Unity/Assets/Scripts/TestSimScript.cs
+++ b/RoboVac Unity/Assets/Scripts/TestSimScript.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TestSimScript : MonoBehaviour
+{   
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    public void SaySomething(string s)
+    {
+        Debug.Log(s);
+    }
+
+}

--- a/RoboVac Unity/Assets/Scripts/TestSimScript.cs.meta
+++ b/RoboVac Unity/Assets/Scripts/TestSimScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f1b4eaba76c90140b81bb2ebedc732d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RoboVac Unity/Assets/SimUI/New Floorplan Menu.prefab
+++ b/RoboVac Unity/Assets/SimUI/New Floorplan Menu.prefab
@@ -989,6 +989,17 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 8636017001068364405}
+        m_MethodName: SendData
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &5710015611908347430
 GameObject:
   m_ObjectHideFlags: 0
@@ -1116,6 +1127,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   menu: {fileID: 5710015611977146726}
+  fileName: {fileID: 5710015612254317014}
+  roomWidth: {fileID: 5710015612430871957}
+  roomHeight: {fileID: 5710015612247270821}
+  carpetType: {fileID: 5710015611377938459}
 --- !u!1 &5710015611979179649
 GameObject:
   m_ObjectHideFlags: 0

--- a/RoboVac Unity/ProjectSettings/ProjectVersion.txt
+++ b/RoboVac Unity/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.3.4f1
-m_EditorVersionWithRevision: 2019.3.4f1 (4f139db2fdbd)
+m_EditorVersion: 2019.3.0f6
+m_EditorVersionWithRevision: 2019.3.0f6 (27ab2135bccf)


### PR DESCRIPTION
Adding in a test script for moving data out of temporary menus like the New Floorplan Menu and the Roomba Settings menu. The scene "tj" is set up with these changes. The Script to take the data from a temporary menu should be attached to the "Canvas" object in the scene and the Script it self should be fetched via GetComponentInParent<SCRIPT NAME>. This example is viewable through the NewFloorplanManager script.